### PR TITLE
Added propTypes example and tests

### DIFF
--- a/Utils/index.js
+++ b/Utils/index.js
@@ -1,3 +1,5 @@
+import checkPropsTypes from 'check-prop-types'
+
 /**
  * Find elements inside of a component by provided attribute
  * @param component React component
@@ -6,4 +8,14 @@
  */
 export const findByAttr = (component, attr) => {
     return component.find(attr)
+}
+
+/**
+ * Check for validity of props in a component
+ * @param component React component
+ * @param expectedProps Expected propTypes
+ * @return {string}
+ */
+export const checkProps = (component, expectedProps) => {
+    return checkPropsTypes(component.PropTypes, expectedProps, "props", component.name)
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "node-sass": "^4.14.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1"
@@ -35,6 +36,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "jest-enzyme": "^7.1.2",
-    "node-sass": "^4.14.0"
+    "check-prop-types": "^1.1.2",
+    "prop-types": "^15.7.2"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,22 @@ import Header from "./component/header"
 import HeadLine from "./component/headline"
 import './app.scss'
 
+const tempArr = [{
+    fName: "John",
+    lName: "Doe",
+    email: "john@doe.co",
+    age: 21,
+    onlineStatus: true
+}]
+const header = "Posts"
+const desc = "How do you do?"
+
 function App() {
   return (
     <div className="App">
       <Header />
       <section className="main">
-          <HeadLine header="Posts" desc="How do you do?"/>
+          <HeadLine header={header} description={desc} tempArr={tempArr}/>
       </section>
     </div>
   );

--- a/src/component/headline/headline.test.js
+++ b/src/component/headline/headline.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { shallow } from "enzyme"
 import HeadLine from "./index"
 
-import { findByAttr } from "../../../Utils"
+import { findByAttr, checkProps } from "../../../Utils"
 
 const headlineComponentClassName = ".headlineComponent"
 const headerClassName = ".header"
@@ -12,6 +12,25 @@ const setUp = (props={}) => {
 }
 
 describe("Headline Component", () => {
+
+    describe("Checking propTypes", () => {
+        it("should not throw warning", () => {
+            const expectedProps = {
+                header: "Test Header",
+                description: "Test Description",
+                tempArr: [{
+                    fName: "Test fName",
+                    lName: "Test lName",
+                    email: "test@email.com",
+                    age: 22,
+                    onlineStatus: false
+                }]
+            }
+            const propsError = checkProps(HeadLine, expectedProps)
+            expect(propsError).toBeUndefined()
+        })
+    })
+
     describe("Have props", () => {
         let component
         beforeEach(() => {

--- a/src/component/headline/index.js
+++ b/src/component/headline/index.js
@@ -1,21 +1,34 @@
 import React, {Component} from "react"
+import PropTypes from 'prop-types'
 
 class HeadLine extends Component {
     constructor(props) {
         super(props);
     }
     render() {
-        const { header, desc } = this.props
+        const { header, description} = this.props
         if(!header) {
             return null
         }
         return (
             <div className="headlineComponent">
                 <h1 className="header">{header}</h1>
-                <p className="description">{desc}</p>
+                <p className="description">{description}</p>
             </div>
         )
     }
+}
+
+HeadLine.propTypes = {
+    header: PropTypes.string,
+    description: PropTypes.string,
+    tempArr: PropTypes.arrayOf(PropTypes.shape({
+        fName: PropTypes.string,
+        lName: PropTypes.string,
+        email: PropTypes.string,
+        age: PropTypes.number,
+        onlineStatus: PropTypes.bool
+    }))
 }
 
 export default HeadLine

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,6 +2812,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+check-prop-types@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/check-prop-types/-/check-prop-types-1.1.2.tgz#c42df4fbdb509fbd4d8a102d113bb0ca01c21e67"
+  integrity sha512-hGDrZ1yhRgKuP1yzZ5sUX/PPmlKBLOF1GyF0Z008Sienko3BFZmlCXnmq+npRTIL/WlFCUzThyd+F5PQnnT1ug==
+
 cheerio@^1.0.0-rc.3:
   version "1.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"


### PR DESCRIPTION
#### Description
As your app grows, you can catch a lot of bugs with typechecking. For some applications, you can use JavaScript extensions like Flow or TypeScript to typecheck your whole application. But even if you don’t use those, React has some built-in typechecking abilities. To run typechecking on the props for a component, you can assign the special propTypes property
#### Motivation
PropTypes exports a range of validators that can be used to make sure the data you receive is valid. In this example, we’re using PropTypes.string. When an invalid value is provided for a prop, a warning will be shown in the JavaScript console. For performance reasons, propTypes is only checked in development mode.