### PR TITLE
Added postsReducer with tests

### DIFF
--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -1,0 +1,3 @@
+export const types = {
+    GET_POSTS: 'getPosts'
+}

--- a/src/reducer/index.js
+++ b/src/reducer/index.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux'
-import success from "./successReducer"
+import posts from "./posts/reducer"
 
 export default combineReducers({
-    success
+    posts
 })

--- a/src/reducer/posts/reducer.js
+++ b/src/reducer/posts/reducer.js
@@ -1,0 +1,10 @@
+import {types} from "../../actions/types"
+
+export default (state=[], action) => {
+    switch (action.type) {
+        case types.GET_POSTS:
+            return action.payload
+        default:
+            return state
+    }
+}

--- a/src/reducer/posts/reducer.test.js
+++ b/src/reducer/posts/reducer.test.js
@@ -1,0 +1,18 @@
+import {types} from "../../actions/types"
+import postsReducer from "./reducer"
+
+describe("Post reducer", () => {
+    it("should return default state", () => {
+        const newState = postsReducer(undefined, {})
+        expect(newState).toEqual([])
+    })
+
+    it("should return new state if receiving type", () => {
+        const posts = [{title: "Test 1"}, {title: "Test 2"}, {title: "Test 3"}]
+        const newState = postsReducer(undefined, {
+            type: types.GET_POSTS,
+            payload: posts
+        })
+        expect(newState).toEqual(posts)
+    })
+})

--- a/src/reducer/successReducer.js
+++ b/src/reducer/successReducer.js
@@ -1,3 +1,0 @@
-export default (state, action) => {
-    return null
-}


### PR DESCRIPTION
Previously we'd created a `successReducer` returning just `null`. Why :confused: ?
Its because whenever we implement `redux` and create a `store` then  we have pass at least one reducer to the store otherwise we've to face bunch of errors.

With this PR:
- gimmick reducer is removed
- very simple `postsReducer` is added
- tests added for Posts reducer